### PR TITLE
Close The Connection After Polling

### DIFF
--- a/lib/newrelic_postgres_plugin/agent.rb
+++ b/lib/newrelic_postgres_plugin/agent.rb
@@ -67,6 +67,8 @@ module NewRelic::PostgresPlugin
       report_bgwriter_metrics
       report_database_metrics
       report_index_metrics
+      
+      @connection.finish
     rescue => e
       $stderr.puts "#{e}: #{e.backtrace.join("\n  ")}"
     end


### PR DESCRIPTION
Closes the database connection after polling, seems to prevent a build up of open connections and curbs the memory usage of the plugin.
