### PR TITLE
Requiring newrelic_plugin ~> 1.0.2 in a single place

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
-gem "newrelic_plugin", "~> 1.0.2"
-gem "pg"
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,24 @@
-GEM
-  remote: http://rubygems.org/
+PATH
+  remote: .
   specs:
-    faraday (0.8.7)
-      multipart-post (~> 1.1)
+    newrelic_postgres_plugin (0.1.6)
+      newrelic_plugin (~> 1.0.2)
+      pg (>= 0.15.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    faraday (0.8.8)
+      multipart-post (~> 1.2.0)
     json (1.8.0)
     multipart-post (1.2.0)
-    newrelic_plugin (1.0.2)
+    newrelic_plugin (1.0.3)
       faraday (>= 0.8.1)
       json
-    pg (0.15.1)
+    pg (0.16.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  newrelic_plugin (~> 1.0.2)
-  pg
+  newrelic_postgres_plugin!

--- a/newrelic_postgres_plugin.gemspec
+++ b/newrelic_postgres_plugin.gemspec
@@ -51,7 +51,7 @@ This is the New Relic plugin for monitoring Postgres developed by Boundless Inc.
   ## The newrelic_plugin needs to be installed.  Prior to public release, the
   # gem needs to be downloaded from git@github.com:newrelic-platform/newrelic_plugin.git
   # and built using the "rake build" command
-  s.add_dependency('newrelic_plugin', ">= 0.2.11")
+  s.add_dependency('newrelic_plugin', "~> 1.0.2")
   s.add_dependency('pg', ">= 0.15.1")
 
   s.post_install_message = <<-EOF


### PR DESCRIPTION
This unifies the Gemfile and the .gemspec version dependencies

Fixes #10
