### PR TITLE
Reuse VERSION constant in plugin output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ def name
 end
 
 def version
-  line = File.read("lib/#{name}.rb")[/^\s*VERSION\s*=\s*.*/]
+  line = File.read("lib/#{name}/version.rb")[/^\s*VERSION\s*=\s*.*/]
   line.match(/.*VERSION\s*=\s*['"](.*)['"]/)[1]
 end
 

--- a/lib/newrelic_postgres_plugin.rb
+++ b/lib/newrelic_postgres_plugin.rb
@@ -1,6 +1,8 @@
 require 'rubygems'
-require 'newrelic_postgres_plugin/agent'
+require 'bundler/setup'
 
-module NewRelic::PostgresPlugin
-  VERSION = '0.1.6'
-end
+require 'newrelic_plugin'
+require 'pg'
+
+require 'newrelic_postgres_plugin/version'
+require 'newrelic_postgres_plugin/agent'

--- a/lib/newrelic_postgres_plugin/agent.rb
+++ b/lib/newrelic_postgres_plugin/agent.rb
@@ -1,10 +1,3 @@
-#!/usr/bin/env ruby
-
-require 'rubygems'
-require 'bundler/setup'
-require 'newrelic_plugin'
-require 'pg'
-
 module NewRelic::PostgresPlugin
 
   # Register and run the agent
@@ -20,7 +13,7 @@ module NewRelic::PostgresPlugin
   class Agent < NewRelic::Plugin::Agent::Base
 
     agent_guid    'com.boundless.postgres'
-    agent_version '1.0.0'
+    agent_version NewRelic::PostgresPlugin::VERSION
     agent_config_options :host, :port, :user, :password, :dbname, :sslmode, :label
     agent_human_labels('Postgres') { "#{label || host}" }
 

--- a/lib/newrelic_postgres_plugin/version.rb
+++ b/lib/newrelic_postgres_plugin/version.rb
@@ -1,0 +1,3 @@
+module NewRelic::PostgresPlugin
+  VERSION = '0.1.6'
+end


### PR DESCRIPTION
This does mean the displayed version changes from '1.0.0' to '0.1.6', but now it at least matches the gem-version installed. This should hopefully be less confusing for end-users.

What do you guys think, is this useful?
