### PR TITLE
Fix improper conditional in report derived metric

### DIFF
--- a/bin/pg_monitor
+++ b/bin/pg_monitor
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
-$LOAD_PATH.unshift File.expand_path "../../lib", __FILE__
-require "newrelic_postgres_plugin"
+$LOAD_PATH.unshift File.expand_path '../../lib', __FILE__
+require 'newrelic_postgres_plugin'
 require 'optparse'
 
 options = OptionParser.new do |opts|
@@ -9,23 +9,23 @@ Usage:
   newrelic_postgres_plugin ( run | install ) [options]
 EOF
 
-  opts.on("-v", "--verbose", "Run verbosely") do
+  opts.on('-v', '--verbose', 'Run verbosely') do
     NewRelic::Plugin::Config.config.newrelic['verbose'] = 1
   end
 
-  opts.on("-l", "--license LICENSE_KEY", "Your NewRelic account License Key") do | license_key |
+  opts.on('-l', '"--license LICENSE_KEY", "Your NewRelic account License Key"') do | license_key |
     $license_key = license_key
   end
 
-  opts.on("-c", "--config FILE", "Override the location of the newrelic_plugin.yml") do | filename |
-    if !File.exists? filename
+  opts.on('-c', '--config FILE', 'Override the location of the newrelic_plugin.yml') do | filename |
+    unless File.exists? filename
       puts "File not found: #{filename.inspect}"
       exit 1
     end
     NewRelic::Plugin::Config.config_file = filename
   end
 
-  opts.on("-h", "--help") do
+  opts.on('-h', '--help') do
     puts opts
     if File.basename($0) == File.basename(__FILE__)
       exit 0
@@ -36,22 +36,22 @@ end
 
 args = options.parse!(ARGV)
 
-if args.first == "run"
+if args.first == 'run'
   if $license_key
     NewRelic::Plugin::Config.config.options['newrelic']['license_key'] = $license_key
   end
   NewRelic::PostgresPlugin.run
-elsif args.first == "install"
-  config_file = File.read(File.expand_path("../../config/newrelic_plugin.yml", __FILE__))
+elsif args.first == 'install'
+  config_file = File.read(File.expand_path('../../config/newrelic_plugin.yml', __FILE__))
   if $license_key
-    config_file.gsub!("YOUR_LICENSE_KEY_HERE", $license_key)
+    config_file.gsub!('YOUR_LICENSE_KEY_HERE', $license_key)
   end
   require 'fileutils'
-  FileUtils.mkdir_p "config"
-  File.open("config/newrelic_plugin.yml", "w") do | io |
+  FileUtils.mkdir_p 'config'
+  File.open('config/newrelic_plugin.yml', 'w') do | io |
     io.write(config_file)
   end
-  puts "Saved agent config file #{File.expand_path("config/newrelic_plugin.yml")}"
+  puts "Saved agent config file #{File.expand_path('config/newrelic_plugin.yml')}"
 else
   puts options
 end

--- a/lib/newrelic_postgres_plugin/agent.rb
+++ b/lib/newrelic_postgres_plugin/agent.rb
@@ -66,42 +66,42 @@ module NewRelic::PostgresPlugin
 
     def report_metrics
       @connection.exec(backend_query) do |result|
-        report_metric "Backends/Active", 'connections', result[0]['backends_active']
-        report_metric "Backends/Idle",   'connections', result[0]['backends_idle']
+        report_metric 'Backends/Active', 'connections', result[0]['backends_active']
+        report_metric 'Backends/Idle',   'connections', result[0]['backends_idle']
       end
       @connection.exec(database_query) do |result|
         result.each do |row|
-          report_metric         "Database/Backends",                 '', row['numbackends'].to_i
-          report_derived_metric "Database/Transactions/Committed",   'transactions', row['xact_commit'].to_i
-          report_derived_metric "Database/Transactions/Rolled Back", 'transactions', row['xact_rollback'].to_i
+          report_metric         'Database/Backends',                 '', row['numbackends'].to_i
+          report_derived_metric 'Database/Transactions/Committed',   'transactions', row['xact_commit'].to_i
+          report_derived_metric 'Database/Transactions/Rolled Back', 'transactions', row['xact_rollback'].to_i
 
-          report_derived_metric "Database/Rows/Selected", 'rows', row['tup_returned'].to_i + row['tup_fetched'].to_i
-          report_derived_metric "Database/Rows/Inserted", 'rows', row['tup_inserted'].to_i
-          report_derived_metric "Database/Rows/Updated",  'rows', row['tup_updated'].to_i
-          report_derived_metric "Database/Rows/Deleted",  'rows', row['tup_deleted'].to_i
+          report_derived_metric 'Database/Rows/Selected', 'rows', row['tup_returned'].to_i + row['tup_fetched'].to_i
+          report_derived_metric 'Database/Rows/Inserted', 'rows', row['tup_inserted'].to_i
+          report_derived_metric 'Database/Rows/Updated',  'rows', row['tup_updated'].to_i
+          report_derived_metric 'Database/Rows/Deleted',  'rows', row['tup_deleted'].to_i
 
         end
       end
       @connection.exec(index_count_query) do |result|
-        report_metric "Database/Indexes/Count", 'indexes', result[0]['indexes'].to_i
+        report_metric 'Database/Indexes/Count', 'indexes', result[0]['indexes'].to_i
       end
       @connection.exec(index_size_query) do |result|
-        report_metric "Database/Indexes/Size", 'bytes', result[0]['size'].to_i
+        report_metric 'Database/Indexes/Size', 'bytes', result[0]['size'].to_i
       end
       @connection.exec(bgwriter_query) do |result|
-        report_derived_metric "Background Writer/Checkpoints/Scheduled", 'checkpoints', result[0]['checkpoints_timed'].to_i
-        report_derived_metric "Background Writer/Checkpoints/Requested", 'checkpoints', result[0]['checkpoints_requests'].to_i
+        report_derived_metric 'Background Writer/Checkpoints/Scheduled', 'checkpoints', result[0]['checkpoints_timed'].to_i
+        report_derived_metric 'Background Writer/Checkpoints/Requested', 'checkpoints', result[0]['checkpoints_requests'].to_i
       end
-      report_metric "Alerts/Index Miss Ratio", '%', calculate_miss_ratio(%Q{SELECT SUM(idx_blks_hit) AS hits, SUM(idx_blks_read) AS reads FROM pg_statio_user_indexes})
-      report_metric "Alerts/Cache Miss Ratio", '%', calculate_miss_ratio(%Q{SELECT SUM(heap_blks_hit) AS hits, SUM(heap_blks_read) AS reads FROM pg_statio_user_tables})
+      report_metric 'Alerts/Index Miss Ratio', '%', calculate_miss_ratio(%Q{SELECT SUM(idx_blks_hit) AS hits, SUM(idx_blks_read) AS reads FROM pg_statio_user_indexes})
+      report_metric 'Alerts/Cache Miss Ratio', '%', calculate_miss_ratio(%Q{SELECT SUM(heap_blks_hit) AS hits, SUM(heap_blks_read) AS reads FROM pg_statio_user_tables})
 
       # This is dependent on the pg_stat_statements being loaded, and assumes that pg_stat_statements.max has been set sufficiently high that most queries will be recorded. If your application typically generates more than 1000 distinct query plans per sampling interval, you're going to have a bad time.
-      if extension_loaded? "pg_stat_statements"
-        @connection.exec("SELECT SUM(calls) FROM pg_stat_statements") do |result|
-          report_derived_metric "Database/Statements", '', result[0]["sum"].to_i
+      if extension_loaded? 'pg_stat_statements'
+        @connection.exec('SELECT SUM(calls) FROM pg_stat_statements') do |result|
+          report_derived_metric 'Database/Statements', '', result[0]['sum'].to_i
         end
       else
-        puts "pg_stat_statements is not loaded; no Database/Statements metric will be reported."
+        puts 'pg_stat_statements is not loaded; no Database/Statements metric will be reported.'
       end
     end
 
@@ -109,12 +109,12 @@ module NewRelic::PostgresPlugin
 
       def extension_loaded?(extname)
         @connection.exec("SELECT count(*) FROM pg_extension WHERE extname = '#{extname}'") do |result|
-          result[0]["count"] == "1"
+          result[0]['count'] == '1'
         end
       end
 
       def report_derived_metric(name, units, value)
-        if previous_value = @previous_metrics[name]
+        if previous_value == @previous_metrics[name]
           report_metric name, units, (value - previous_value)
         else
           report_metric name, units, 0
@@ -128,8 +128,8 @@ module NewRelic::PostgresPlugin
         sample.each { |key,value| sample[key] = value.to_i }
         miss_ratio = if check_samples(@previous_result_for_query[query], sample)
 
-          hits = sample["hits"] - @previous_result_for_query[query]["hits"]
-          reads = sample["reads"] - @previous_result_for_query[query]["reads"]
+          hits = sample['hits'] - @previous_result_for_query[query]['hits']
+          reads = sample['reads'] - @previous_result_for_query[query]['reads']
           
           if (hits + reads) == 0
             0.0
@@ -141,14 +141,14 @@ module NewRelic::PostgresPlugin
         end
       
         @previous_result_for_query[query] = sample
-        return miss_ratio
+        miss_ratio
       end
  
       # Check if we don't have a time dimension yet or metrics have decreased in value.
       def check_samples(last, current)
         return false if last.nil? # First sample?
         return false unless current.find { |k,v| last[k] > v }.nil? # Values have gone down?
-        return true
+        true
       end
 
       def backend_query
@@ -178,7 +178,7 @@ module NewRelic::PostgresPlugin
       end
 
       def bgwriter_query
-        "SELECT * FROM pg_stat_bgwriter;"
+        'SELECT * FROM pg_stat_bgwriter;'
       end
 
       def index_count_query
@@ -186,7 +186,7 @@ module NewRelic::PostgresPlugin
       end
 
       def index_size_query
-        "SELECT sum(relpages::bigint*8192) AS size FROM pg_class WHERE reltype = 0;"
+        'SELECT sum(relpages::bigint*8192) AS size FROM pg_class WHERE reltype = 0;'
       end
 
   end


### PR DESCRIPTION
I noticed that the if logic in `agent#report_derived_metric` used a single quote for comparison rather than double. I changed that as well as a few stylistic things: removed explicit returns at the end of methods; changed double quotes to single on strings that did not need interpolation, and changed an `if !File.exists` to `unless File.exists in Usage.

Most of it is small but the single equals in the if clause looked like a bug.
